### PR TITLE
fix(deps): upgrade Pillow to 12.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,7 @@ arxiv
 pyinstaller # Added for EXE packaging
 requests
 
-pillow~=11.1.0
+pillow~=12.3.0
 numpy~=2.2.2
 werkzeug # Added as Flask dependency, good to be explicit
 pytest # Added for unit testing


### PR DESCRIPTION
## Summary

- upgrade Pillow from `~=11.1.0` to `~=12.3.0`
- resolves CVE-2026-59197 (heap out-of-bounds write in `ImageFilter.RankFilter`)

## Verification

- verified the constraint is restricted to Pillow 12.3.x
- ran `git diff --check`